### PR TITLE
Update GH Actions dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python 3.13
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
     - name: Install dependencies


### PR DESCRIPTION
This update looked like a quick win.

If that's okay, I can submit a Renovate config to autamote these updates too.