### PR TITLE
Use `hatch` to build on GH

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
-      - name: Install pypa/build
-        run: python3 -m pip install build --user
+      - name: Install Hatchling
+        run: python3 -m pip install .[build] --user
       - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+        run: hatch build
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,13 @@ Documentation = "https://django-admin-action-hero.readthedocs.io/en/latest/"
 Repository = "https://github.com/kennethlove/django-admin-action-hero"
 
 [dependency-groups]
+build = [
+    "hatchling>=1.28.0",
+]
 dev = [
     "celery-types==0.23.0",
     "django-stubs>=5.2.8",
     "faker>=38.2.0",
-    "hatchling>=1.28.0",
     "pytest>=9.0.1",
     "pytest-celery>=1.2.1",
     "pytest-cov>=7.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Since the project uses `hatchling` as its build system, the project should use `hatch` instead of `python3 -m build`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->

None, I'm special

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Consistency. It might make more sense to just change the build system but I don't want to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It'll be tested live, I guess. Is there another way to test workflows?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
