### PR TITLE
Updated PR template yet again.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,30 @@
 <!--- Provide a general summary of your changes in the Title above -->
 
+## PR type
+
+<!--- Are you making a PR to refactor code, fix a bug, or to add a feature? -->
+
+- [ ] Refactoring
+- [ ] Bugfix
+- [ ] Feature
+
 ## Description
+
 <!--- Describe your changes in detail -->
 
 ## Related Issue
+
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- Please link to the issue here: -->
 
 ## Motivation and Context
+
 <!--- Why is this change required? What problem does it solve? -->
 
 ## How Has This Been Tested?
+
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
@@ -20,17 +32,24 @@
 ## Screenshots (if appropriate):
 
 ## Types of changes
+
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Refactoring (no functional changes)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
 ## Checklist:
+
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have read the **CONTRIBUTING** document.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
+
+<!--- Thanks for your hard work! -->


### PR DESCRIPTION

## Description

GitHub allows multiple PR templates but only exposes them via the `?template` query arg. I'm not sure how to make people use those URLs so I'm provided a more bland, all-encompassing default template.

## Related Issue

none

## Motivation and Context

It makes PRs more uniform.

## How Has This Been Tested?

You know how (it hasn't)

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
